### PR TITLE
docs: tighten widget and commit=False documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -8,14 +8,14 @@ Advanced configuration examples and third-party widget integrations.
    :local:
 
 .. seealso::
-   The :ref:`recipe-ajax-widget` provides a complete, end-to-end recipe for
-   integrating third-party AJAX widgets.
+   The :ref:`recipe-ajax-widget` provides a practical integration pattern for
+   third-party AJAX widgets.
 
 Widgets
 -------
 
 -  **Default single-select**: ``forms.Select``
--  **Default multi-select**: ``forms.FilteredSelectMultiple``
+-  **Default multi-select**: ``django.contrib.admin.widgets.FilteredSelectMultiple``
 -  **Custom**: Any Django form widget, including those from third-party apps
    like `django-autocomplete-light <https://django-autocomplete-light.readthedocs.io/>`_,
    can be provided via ``ReverseRelationConfig.widget``.

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -129,8 +129,10 @@ class; the mixin then wires dynamic form fields, validation, permissions, and
 persistence logic around Django's normal flow.
 
 1. **Field declaration** — the admin declares :term:`virtual field <Virtual Field>` names in
-   ``reverse_relations`` and lists them in ``fieldsets`` so the Django admin
-   template renders them.
+   ``reverse_relations`` and typically lists them in ``fieldsets`` or ``fields``
+   so the Django admin template renders them. When neither layout option is
+   declared, :meth:`~django_admin_reversefields.mixins.ReverseRelationAdminMixin.get_fields`
+   appends virtual names automatically.
 2. **Form construction** — :meth:`~django_admin_reversefields.mixins.ReverseRelationAdminMixin.get_form`
    strips the virtual names out of the base ``fields`` argument (to avoid
    Django's "unknown field" errors) and delegates to ``super()``. After the base
@@ -189,6 +191,21 @@ transient uniqueness conflicts on ``OneToOneField`` or ``unique`` ForeignKeys.
    until :meth:`~django.contrib.admin.options.ModelAdmin.save_model`. The
    payload of authorized reverse fields is stored on the form instance and
    applied during the admin save hook.
+
+   Typical use-cases
+      - You override admin save hooks and need to inspect or adjust the parent
+        instance before reverse bindings are persisted.
+      - You rely on the standard Django admin lifecycle where
+        ``ModelAdmin.save_model`` coordinates the final write.
+
+   Behavioral details
+      1. ``form.save(commit=False)`` returns the parent instance without
+         applying reverse bind/unbind updates yet.
+      2. The mixin stores only authorized reverse-field selections on the form.
+      3. :meth:`~django.contrib.admin.options.ModelAdmin.save_model` applies the
+         deferred payload exactly once.
+      4. Hidden/disabled/unauthorized fields remain excluded from persistence,
+         consistent with normal ``commit=True`` behavior.
 
 .. _concepts-data-integrity:
 

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -459,14 +459,14 @@ significant performance improvements but bypasses model signals.
 Third-party widgets (AJAX search)
 ---------------------------------
 
-.. dropdown:: End-to-end DAL integration
+.. dropdown:: DAL integration pattern
    :open:
 
    .. seealso::
       See :doc:`advanced` for more details on widget customisation.
 
    You can use any compatible third-party widget, which is especially useful for
-   fields with many choices. The example below shows a conceptual integration with
+   fields with many choices. The example below shows one integration pattern with
    `django-autocomplete-light <https://django-autocomplete-light.readthedocs.io/>`_
    to provide an AJAX-powered search widget.
 


### PR DESCRIPTION
Summary
- correct default multi-select widget reference to django.contrib.admin.widgets.FilteredSelectMultiple
- reword DAL section as an integration pattern instead of an end-to-end guarantee
- clarify field declaration lifecycle wording for fieldsets or fields versus get_fields auto-append
- expand commit=False note with typical use cases and stepwise behavior details

Validation
- uv run python -m sphinx -b html docs docs/_build/html -W