### PR TITLE
ci: optimize test workflow frequency and runtime

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,15 +14,51 @@ on:
             - "docs/**"
             - ".github/release-drafter.yml"
 
+concurrency:
+    group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
+
 jobs:
-    test:
-        name: Run Tests
+    test_pr:
+        name: Run PR Tests
+        if: github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    # supporting Python 3.10-3.12
+                    - python-version: "3.11"
+                      django-version: "4.2"
+                    - python-version: "3.12"
+                      django-version: "5.2"
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install UV
+              uses: astral-sh/setup-uv@v5
+              with:
+                  version: "0.6.5"
+                  python-version: ${{ matrix.python-version }}
+                  enable-cache: true
+
+            - name: Create venv and install dependencies
+              run: |
+                  uv venv
+                  uv pip install "django==${{ matrix.django-version }}"
+                  uv sync --all-extras --dev
+
+            - name: Run Tests
+              run: uv run python manage.py test -v 2
+
+    test_main:
+        name: Run Full Matrix on Main
+        if: github.event_name == 'push'
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
                     - python-version: "3.10"
                       django-version: "4.2"
                     - python-version: "3.11"


### PR DESCRIPTION
Summary
- add workflow concurrency to cancel superseded in-progress test runs per PR/branch
- split test jobs by event type:
  - pull_request: reduced smoke matrix (3.11/4.2 and 3.12/5.2)
  - push to main: full compatibility matrix (3.10-3.13 x Django 4.2/5.0/5.1/5.2)
- keep existing path-ignore filters so docs/markdown-only changes do not trigger the test workflow

Why
- reduce CI load and feedback latency on PRs
- retain full compatibility coverage on main before releases

Notes
- no test logic changed; only GitHub Actions workflow behavior changed